### PR TITLE
Fix travis build and codecov

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,11 @@ language: go
 os:
  - linux
 
-# This project contains referecnes to the absolution GitHub path,
+# This project contains references to the absolution GitHub path,
 # e.g. github.com/theodesp/go-heaps/leftlist.
-# That means, by default, if someone forks the repo and makes changes,
-# Travis won't pass for the branch on their own repo. To fix that, we move the directory
+# That means, by default, if someone forks the repo and makes changes, Travis
+# won't pass for the branch on their own repo. To fix that, we move the
+# directory.
 before_install:
  - make debs
  - mkdir -p $TRAVIS_BUILD_DIR $GOPATH/src/github.com/theodesp
@@ -15,18 +16,18 @@ before_install:
 after_success:
  - codecov
 
-go:
- - 1.8.5
- - 1.9.2
- - tip
+# test on the two most recent releases and tip
+ go:
+ - "1.10.x"
+ - "1.11.x"
+ - "tip"
 
 matrix:
  allow_failures:
   - go: tip
 
 script:
- - go test -cpu=2 -race -v ./...
- - go test -cpu=2 -coverprofile=coverage.txt -covermode=atomic ./...
+ - make test
 
 notifications:
  email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,11 +13,8 @@ before_install:
  - mkdir -p $TRAVIS_BUILD_DIR $GOPATH/src/github.com/theodesp
  - test ! -d $GOPATH/src/github.com/theodesp/go-heaps && mv $TRAVIS_BUILD_DIR $GOPATH/src/github.com/theodesp/go-heaps || true
 
-after_success:
- - codecov
-
 # test on the two most recent releases and tip
- go:
+go:
  - "1.10.x"
  - "1.11.x"
  - "tip"
@@ -28,6 +25,9 @@ matrix:
 
 script:
  - make test
+
+after_success:
+ - bash <(curl -s https://codecov.io/bash)
 
 notifications:
  email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,26 +1,26 @@
 language: go
 
 os:
-	- linux
+ - linux
 
 before_install:
-	- make debs
+ - make debs
 
 after_success:
-	- codecov
+ - codecov
 
 go:
-	- 1.8.5
-	- 1.9.2
-	- tip
+ - 1.8.5
+ - 1.9.2
+ - tip
 
 matrix:
-	allow_failures:
-		- go: tip
+ allow_failures:
+  - go: tip
 
 script:
-	- go test -cpu=2 -race -v ./...
-	- go test -cpu=2 -coverprofile=coverage.txt -covermode=atomic ./...
+ - go test -cpu=2 -race -v ./...
+ - go test -cpu=2 -coverprofile=coverage.txt -covermode=atomic ./...
 
 notifications:
-	email: false
+ email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,14 @@ language: go
 os:
  - linux
 
+# This project contains referecnes to the absolution GitHub path,
+# e.g. github.com/theodesp/go-heaps/leftlist.
+# That means, by default, if someone forks the repo and makes changes,
+# Travis won't pass for the branch on their own repo. To fix that, we move the directory
 before_install:
  - make debs
+ - mkdir -p $TRAVIS_BUILD_DIR $GOPATH/src/github.com/theodesp
+ - test ! -d $GOPATH/src/github.com/theodesp/go-heaps && mv $TRAVIS_BUILD_DIR $GOPATH/src/github.com/theodesp/go-heaps || true
 
 after_success:
  - codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,11 +3,12 @@ language: go
 os:
  - linux
 
-# This project contains references to the absolution GitHub path,
+# This project contains references to the absolute GitHub path,
 # e.g. github.com/theodesp/go-heaps/leftlist.
 # That means, by default, if someone forks the repo and makes changes, Travis
 # won't pass for the branch on their own repo. To fix that, we move the
 # directory.
+# From: https://github.com/cloudflare/cfssl/blob/c71f2083af21ebe304311b33831fbbecf42c2738/.travis.yml#L22-L29
 before_install:
  - make debs
  - mkdir -p $TRAVIS_BUILD_DIR $GOPATH/src/github.com/theodesp

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ debs:
 
 .PHONY: test
 test:
-	GOPATH=$(GOPATH) go test -race $$(go list ./... | grep -v example)
+	GOPATH=$(GOPATH) go test -race $$(go list ./... | grep -v example) -coverprofile=coverage.txt -covermode=atomic
 
 .PHONY: bench
 bench:

--- a/Makefile
+++ b/Makefile
@@ -5,13 +5,12 @@ format:
 
 .PHONY: debs
 debs:
-	# GOPATH=$(GOPATH) go get ./...
 	GOPATH=$(GOPATH) go get -u github.com/stretchr/testify
 	GOPATH=$(GOPATH) go get -u github.com/fortytw2/leaktest
 
 .PHONY: test
 test:
-	GOPATH=$(GOPATH) go test -race $(go list ./...)
+	GOPATH=$(GOPATH) go test -race $$(go list ./... | grep -v example)
 
 .PHONY: bench
 bench:

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ format:
 
 .PHONY: debs
 debs:
-	GOPATH=$(GOPATH) go get ./...
+	# GOPATH=$(GOPATH) go get ./...
 	GOPATH=$(GOPATH) go get -u github.com/stretchr/testify
 	GOPATH=$(GOPATH) go get -u github.com/fortytw2/leaktest
 


### PR DESCRIPTION
This PR fixes the TravisCI build and codecov. (Issue #21)

Right now the Travis build is running against go 1.10, 1.11 and tip. Using tip adds about 3 minutes to the build time, so maybe we should consider dropping that.
