### PR TITLE
feat(test): Merge all coverage in one file to parse it with codecov.io

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,14 @@ debs:
 
 .PHONY: test
 test:
-	GOPATH=$(GOPATH) go test -race $$(go list ./... | grep -v example) -coverprofile=coverage.txt -covermode=atomic
+	-rm coverage.txt
+	@for package in $$(go list ./... | grep -v example) ; do \
+		GOPATH=$(GOPATH) go test -race -coverprofile=profile.out -covermode=atomic $$package ; \
+		if [ -f profile.out ]; then \
+			cat profile.out >> coverage.txt ; \
+			rm profile.out ; \
+		fi \
+	done
 
 .PHONY: bench
 bench:


### PR DESCRIPTION
Even after the fix about `$$(go list ./... | grep -v example)` in the Makefile. I was not able to run `make test` on local because of
```
GOPATH=/home/lhauspie/go go test -race $(go list ./... | grep -v example) -coverprofile=coverage.txt -covermode=atomic
cannot use test profile flag with multiple packages
Makefile:13: recipe for target 'test' failed
make: *** [test] Error 1
```

So I replaced this one command line by a loop over the go sub packages and then run test on each one and then merge the cover profile files into a final `coverage.txt` file that will be readable by codecov.io

Now everybody will be able to run tests locally.