### PR TITLE
feat(leftist heap): change test to fit example and then fix the test

### DIFF
--- a/leftist/leftist_heap.go
+++ b/leftist/leftist_heap.go
@@ -54,7 +54,7 @@ func merge(x, y *Node) *Node {
 
 // Init initializes or clears the LeftistHeap
 func (h *LeftistHeap) Init() *LeftistHeap {
-	h.root = &Node{}
+	h.root = nil
 	return h
 }
 
@@ -84,6 +84,9 @@ func (h *LeftistHeap) DeleteMin() heap.Item {
 // FindMin finds the minimum value.
 // The complexity is O(1).
 func (h *LeftistHeap) FindMin() heap.Item {
+	if h.root == nil {
+		return nil
+	}
 	return h.root.item
 }
 

--- a/leftist/leftist_heap_test.go
+++ b/leftist/leftist_heap_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestLeftistHeapInteger(t *testing.T) {
-	heap := &LeftistHeap{}
+	heap := New().Init()
 
 	numbers := []int{4, 3, 2, 5}
 


### PR DESCRIPTION
`$ go run example/leftist/leftist.go` was raising:
```
panic: interface conversion: go_heaps.Item is nil, not go_heaps.Integer

goroutine 1 [running]:
github.com/theodesp/go-heaps.Integer.Compare(...)
        /home/lhauspie/go/src/github.com/theodesp/go-heaps/heap.go:77
github.com/theodesp/go-heaps.(*Integer).Compare(0xc42001c100, 0x0, 0x0, 0xc42007c180)
        <autogenerated>:1 +0x9d
github.com/theodesp/go-heaps/leftist.mergeNodes(0xc42007c180, 0xc42007c150, 0x7f299e107200)
        /home/lhauspie/go/src/github.com/theodesp/go-heaps/leftist/leftist_heap.go:28 +0x5f
github.com/theodesp/go-heaps/leftist.(*LeftistHeap).Insert(0xc420049f28, 0x51c220, 0xc42001c100, 0xc42001c100, 0xc42008a168)
        /home/lhauspie/go/src/github.com/theodesp/go-heaps/leftist/leftist_heap.go:67 +0x6b
main.main()
        /home/lhauspie/go/src/github.com/theodesp/go-heaps/example/leftist/leftist.go:12 +0xa0
exit status 2
```

because the Init function of leftist heap was:
```golang
func (h *LeftistHeap) Init() *LeftistHeap {
	h.root = &Node{} // <==== Item is nil here
	return h
}
```

So when we first tried to insert an Item, the `mergeNodes` function was comparing the item of the new node with the item of the heap root wich was `nil` and then failed