### PR TITLE
fix maxBucketSize

### DIFF
--- a/rank_pairing/rank_pairing_heap.go
+++ b/rank_pairing/rank_pairing_heap.go
@@ -284,7 +284,7 @@ func merge(r0, r1 *RPHeap) *RPHeap {
 }
 
 func (r *RPHeap) maxBucketSize() int {
-	bit, cnt := 1, r.size
+	bit, cnt := 0, r.size
 	for cnt > 1 {
 		cnt /= 2
 		bit++


### PR DESCRIPTION
This PR tries to make `maxBucketSize` more close to `(log n) + 1`.

i.e, it returns 1 for size 1, returns 2 for size 2,3, returns 3 for size 4,5,6,7 etc.